### PR TITLE
Improve diary table and docs

### DIFF
--- a/Gefuehls-Trigger-Tagebuch.markdown
+++ b/Gefuehls-Trigger-Tagebuch.markdown
@@ -3,6 +3,9 @@
 ## 📝 Heutiges Datum
 [Hier das Datum einfügen, z. B. 29.06.2025]
 
+## Anleitung
+Trage Datum, Situation und Gedanken möglichst zeitnah ein. Verwende kurze Stichworte, um dich später besser erinnern zu können.
+
 ## 🎯 Ziel des Tagebuchs
 Dieses Tagebuch hilft dir, deine Gefühle und Auslöser (Trigger) zu erkennen und zu verstehen, wie sie mit deiner Geschichte (z. B. Traumatisierungen, neurologische Veränderungen) zusammenhängen.
 

--- a/Therapieplan-Uebersicht.markdown
+++ b/Therapieplan-Uebersicht.markdown
@@ -39,6 +39,9 @@ Dieser Plan fasst die Ansätze von Psychotherapeut, Neurologe, DBT-Spezialist un
 - **Ziel**: Verarbeitung traumatischer Erinnerungen, Wiederherstellung von Kontrolle.
 - **Stell dir vor**: Deine Erinnerungen sind wie ein kaputtes Puzzle. Der Experte hilft, die Teile sicher zusammenzusetzen.
 
+## Datenschutz & Weitergabe
+Bewahre diesen Plan an einem geschützten Ort auf und teile ihn nur mit behandelnden Fachpersonen. So bleiben deine persönlichen Daten vertraulich.
+
 ## 📅 Nächste Schritte
 - **Psychotherapeut**: Wöchentliche Sitzungen zur Bearbeitung von Komorbiditäten.
 - **Neurologe**: Regelmäßige Kontrolle von Epilepsie-Medikamenten und neuropsychologische Tests.

--- a/therapeutic_workbook.html
+++ b/therapeutic_workbook.html
@@ -1399,14 +1399,19 @@ Beginne deine Antwort mit einer kurzen, ermutigenden Einschätzung.`;
       const triggerDiary = JSON.parse(localStorage.getItem('triggerDiary')) || [];
       triggerDiary.forEach(entry => {
         const row = document.createElement('tr');
-        row.innerHTML = `
-          <td>${new Date(entry.date).toLocaleDateString()}</td>
-          <td>${entry.trigger}</td>
-          <td>${entry.thought}</td>
-          <td>${entry.body}</td>
-          <td>${entry.reaction}</td>
-          <td>${entry.helpful}</td>
-        `;
+        const cells = [
+          new Date(entry.date).toLocaleDateString(),
+          entry.trigger,
+          entry.thought,
+          entry.body,
+          entry.reaction,
+          entry.helpful
+        ];
+        cells.forEach(text => {
+          const td = document.createElement('td');
+          td.textContent = text;
+          row.appendChild(td);
+        });
         tbody.appendChild(row);
       });
     }
@@ -1417,61 +1422,6 @@ Beginne deine Antwort mit einer kurzen, ermutigenden Einschätzung.`;
     // Trigger-Diary Array
     if (!data.triggers) data.triggers = [];
 
-    function copyToThoughts() {
-      const thought = document.getElementById('thoughtsMood').value.trim();
-      if (thought) {
-        const taggedThought = `[Quelle: Mood-Modul] ${thought}`;
-        document.getElementById('current-thoughts').value = taggedThought;
-        saveThoughts();
-        alert('✅ Gedanke in Gedanken-Sammler übernommen!');
-      }
-    }
-
-    function copyToTriggerDiary() {
-      const situation = document.getElementById('situation').value.trim();
-      const thought = document.getElementById('thoughtsMood').value.trim();
-      const bodyReactions = Array.from(document.querySelectorAll('[name="bodyReactions"]:checked')).map(cb => cb.value);
-      const coping = document.getElementById('copingStrategy').value;
-
-      if (situation) {
-        const triggerEntry = {
-          date: new Date().toISOString(),
-          trigger: situation,
-          thought: thought || '-',
-          body: bodyReactions.join(', ') || '-',
-          reaction: coping || '-',
-          helpful: 'Noch nicht bewertet'
-        };
-        const triggerDiary = JSON.parse(localStorage.getItem('triggerDiary')) || [];
-        triggerDiary.push(triggerEntry);
-        localStorage.setItem('triggerDiary', JSON.stringify(triggerDiary));
-        alert('✅ Trigger wurde ins Trigger-Tagebuch übernommen!');
-        renderClusterTriggerTable();
-      }
-    }
-
-    function renderClusterTriggerTable() {
-      const tbody = document.getElementById('clusterTriggerTableBody');
-      tbody.innerHTML = '';
-
-      const triggerDiary = JSON.parse(localStorage.getItem('triggerDiary')) || [];
-      triggerDiary.forEach(entry => {
-        const row = document.createElement('tr');
-        row.innerHTML = `
-          <td>${new Date(entry.date).toLocaleDateString()}</td>
-          <td>${entry.trigger}</td>
-          <td>${entry.thought}</td>
-          <td>${entry.body}</td>
-          <td>${entry.reaction}</td>
-          <td>${entry.helpful}</td>
-        `;
-        tbody.appendChild(row);
-      });
-    }
-
-    document.addEventListener('DOMContentLoaded', function() {
-      renderClusterTriggerTable();
-    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove duplicate diary functions
- sanitize trigger table output with `textContent`
- add Anleitung section to Gefuehls-Trigger-Tagebuch
- add Datenschutz section to Therapieplan-Uebersicht

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6864e6a401fc832689aa474947ccce0d