### PR TITLE
Encrypt secure data before saving

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -27,17 +27,17 @@ export class TherapyWorkbook {
   }
 
   // 🔧 Initialisierung
-  init() {
-    this.loadData();
+  async init() {
+    await this.loadData();
     this.bindEvents();
     this.initializeCharts();
     this.updateProgress();
-    
+
     // ARIA und Accessibility
     this.setupAccessibility();
-    
+
     // Lade gespeicherte Daten
-    
+
     ToastUtils.show('Therapie-Arbeitsbuch geladen', 'success');
   }
 
@@ -59,13 +59,13 @@ export class TherapyWorkbook {
   }
 
   // 🔒 Sichere Daten-Operationen
-  loadData() {
-    const savedData = StorageUtils.getSecureData('workbook', this.initializeData());
+  async loadData() {
+    const savedData = await StorageUtils.getSecureData('workbook', this.initializeData());
     this.data = { ...this.data, ...savedData };
   }
 
-  saveData() {
-    StorageUtils.setSecureData('workbook', this.data);
+  async saveData() {
+    await StorageUtils.setSecureData('workbook', this.data);
     this.updateProgress();
   }
 
@@ -424,16 +424,16 @@ export class TherapyWorkbook {
   }
 
   // 🔄 Auto-Save
-  autoSave(field) {
+  async autoSave(field) {
     if (!field.value.trim()) return;
 
-    const autoSaveData = StorageUtils.getSecureData('autosave', {});
+    const autoSaveData = await StorageUtils.getSecureData('autosave', {});
     autoSaveData[field.id] = {
       value: SecurityUtils.sanitizeInput(String(field.value)),
       timestamp: new Date().toISOString()
     };
-    
-    StorageUtils.setSecureData('autosave', autoSaveData);
+
+    await StorageUtils.setSecureData('autosave', autoSaveData);
   }
 
   // 📊 Chart-Management
@@ -516,7 +516,7 @@ export class TherapyWorkbook {
   }
 
   // 🔍 Cluster-Trigger-Analyse
-  renderClusterTriggerTable() {
+  async renderClusterTriggerTable() {
     const tbody = document.getElementById('clusterTriggerTableBody');
     if (!tbody) return;
 
@@ -525,8 +525,8 @@ export class TherapyWorkbook {
       tbody.removeChild(tbody.firstChild);
     }
 
-    const triggerDiary = StorageUtils.getSecureData('triggerDiary', []);
-    
+    const triggerDiary = await StorageUtils.getSecureData('triggerDiary', []);
+
     triggerDiary.forEach(entry => {
       const row = DOMUtils.createTableRow([
         new Date(entry.date).toLocaleDateString('de-DE'),
@@ -536,7 +536,7 @@ export class TherapyWorkbook {
         entry.reaction || '',
         entry.helpful || ''
       ]);
-      
+
       tbody.appendChild(row);
     });
 


### PR DESCRIPTION
## Summary
- Encrypt sensitive localStorage entries with AES-GCM using the Web Crypto API and decrypt on retrieval.
- Adjust application flow to await encrypted storage operations for loading, auto-saving and trigger table rendering.

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68916e6010fc8326abb5ef9981e0ab3c