### PR TITLE
feat: prompt for local data consent

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -202,6 +202,9 @@ export class TherapyWorkbook {
         case 'export-privacy-data':
           EventUtils.addSecureListener(btn, 'click', () => this.exportPrivacyData());
           break;
+        case 'confirm-consent':
+          EventUtils.addSecureListener(btn, 'click', () => this.confirmConsent());
+          break;
         // Grounding, PME, etc.
         case 'start-breathing':
           EventUtils.addSecureListener(btn, 'click', () => this.startBreathing());
@@ -618,6 +621,24 @@ export class TherapyWorkbook {
     }
   }
 
+  showConsentModal() {
+    const modal = document.getElementById('consent-modal');
+    if (modal) {
+      modal.style.display = 'block';
+      modal.setAttribute('aria-hidden', 'false');
+      A11yUtils.setFocus(modal);
+    }
+  }
+
+  confirmConsent() {
+    localStorage.setItem('consent', 'true');
+    const modal = document.getElementById('consent-modal');
+    if (modal) {
+      modal.style.display = 'none';
+      modal.setAttribute('aria-hidden', 'true');
+    }
+  }
+
   hideCrisis() {
     const banner = document.getElementById('crisis-banner');
     if (banner) {
@@ -937,6 +958,9 @@ document.addEventListener('DOMContentLoaded', () => {
   // Globale Referenz für Legacy-Kompatibilität
   // @ts-ignore
   window.therapyApp = app;
+  if (!localStorage.getItem('consent')) {
+    app.showConsentModal();
+  }
 });
 
 // Export für Module

--- a/therapeutic_workbook.html
+++ b/therapeutic_workbook.html
@@ -644,6 +644,21 @@
     </div>
   </div>
 
+  <!-- Consent Modal -->
+  <div id="consent-modal" class="modal" aria-hidden="true" role="dialog" aria-labelledby="consent-title" style="display: none;">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2 id="consent-title">📘 Hinweis zur Datenspeicherung</h2>
+      </div>
+      <div class="modal-body">
+        <p>Dieses Arbeitsbuch speichert deine Eingaben nur lokal in deinem Browser.</p>
+        <div class="privacy-actions">
+          <button class="btn btn-primary" data-action="confirm-consent">Verstanden</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Hilfe Modal -->
   <div id="help-modal" class="modal" aria-hidden="true" role="dialog" aria-labelledby="help-title">
     <div class="modal-content">


### PR DESCRIPTION
## Summary
- add modal informing users about local data storage
- on first load show consent modal and store consent choice

## Testing
- `npm test` *(fails: no package.json)*
- `node --check js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6891701102f88326ba778961ed504b1c