### PR TITLE
Add Vier-Ohren chart rendering

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -515,6 +515,71 @@ export class TherapyWorkbook {
     };
   }
 
+  renderOhrChart() {
+    const configs = [
+      { canvasId: 'ohrChart', selectId: 'hearing-pattern' },
+      { canvasId: 'ohrChart-training', selectId: 'hearing-pattern-training' }
+    ];
+
+    const labels = [
+      'Sach-Ohr',
+      'Selbstoffenbarungs-Ohr',
+      'Beziehungs-Ohr',
+      'Appell-Ohr'
+    ];
+    const valueOrder = ['sache', 'selbst', 'beziehung', 'appell'];
+
+    configs.forEach(({ canvasId, selectId }) => {
+      const canvas = document.getElementById(canvasId);
+      if (!(canvas instanceof HTMLCanvasElement)) return;
+
+      if (this.charts.has(canvasId)) {
+        this.charts.get(canvasId).destroy();
+      }
+
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+
+      const select = document.getElementById(selectId);
+      const data = [0, 0, 0, 0];
+
+      if (select && select instanceof HTMLSelectElement) {
+        const idx = valueOrder.indexOf(select.value);
+        if (idx !== -1) {
+          data[idx] = 1;
+        }
+      }
+
+      // @ts-ignore
+      const chart = new window.Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [{
+            label: 'Hörmuster',
+            data,
+            backgroundColor: ['#6366f1', '#10b981', '#f59e0b', '#ef4444']
+          }]
+        },
+        options: {
+          responsive: true,
+          plugins: {
+            legend: { display: false },
+            title: { display: true, text: 'Vier-Ohren-Modell' }
+          },
+          scales: {
+            y: {
+              beginAtZero: true,
+              ticks: { stepSize: 1 }
+            }
+          }
+        }
+      });
+
+      this.charts.set(canvasId, chart);
+    });
+  }
+
   // 🔍 Cluster-Trigger-Analyse
   renderClusterTriggerTable() {
     const tbody = document.getElementById('clusterTriggerTableBody');
@@ -682,6 +747,9 @@ export class TherapyWorkbook {
   showCurrentSlide() {
     const slide = document.getElementById(`slide-${this.currentSlide}`);
     if (slide) slide.classList.add('active');
+    if (this.currentSlide === 6) {
+      this.renderOhrChart();
+    }
   }
 
   updateTrainingUI() {


### PR DESCRIPTION
## Summary
- add `renderOhrChart` using Chart.js to show communication patterns on both 'ohrChart' and 'ohrChart-training'
- render the chart when slide 6 becomes active

## Testing
- `node --check js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68916e63a9d48326b1bc6d4a767b8b67